### PR TITLE
Add root module to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open('HISTORY.rst', 'r', 'utf-8') as f:
 setup(
     name='simpleTR64',
     version=version,
-    packages=['', 'simpletr64.tools', 'simpletr64.actions', 'tests'],
+    packages=['simpletr64', 'simpletr64.tools', 'simpletr64.actions', 'tests'],
     install_requires=['requests'],
     url='http://bpannier.github.io/simpletr64/',
     license='Apache 2.0',


### PR DESCRIPTION
When installed via pip the root package misses `devicetr64.py` and `discover.py`. Adding `simpletr64` as a package fixes this bug.
