### PR TITLE
Tools to scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ---------------
 
+Upcoming Version
+++++++++++++++++++
+* Package installation provides scripts named `simpletr64_...`
+
 1.0.4 (2016-01-11)
 ++++++++++++++++++
 * Adding Fritz specific actions

--- a/bin/simpletr64_deviceinfo
+++ b/bin/simpletr64_deviceinfo
@@ -1,3 +1,5 @@
+#!python
+
 # For a given device finds/load all TR64 informations and print them to stdout
 # Device must be reachable via multicast.
 

--- a/bin/simpletr64_discover
+++ b/bin/simpletr64_discover
@@ -1,3 +1,5 @@
+#!python
+
 import argparse
 import json
 import socket

--- a/bin/simpletr64_execute
+++ b/bin/simpletr64_execute
@@ -1,6 +1,8 @@
+#!python
+
 #
 # Example:
-# execute_action.py -u <username> -p <pw> http://192.168.178.1:49000/upnp/control/hosts
+# simpletr64_discover -u <username> -p <pw> http://192.168.178.1:49000/upnp/control/hosts
 # urn:dslforum-org:service:Hosts:1 GetGenericHostEntry NewIndex::0
 #
 import os

--- a/docs/devices.rst
+++ b/docs/devices.rst
@@ -23,7 +23,7 @@ library.
 
     :meth:`~simpletr64.DeviceTR64.execute`
 
-    The tools which have been provided with this library shows good use of the full library.
+    The scripts which have been provided with this library shows good use of the full library.
 
     `Additional short explanation of the UPnP protocol <http://www.upnp-hacks.org/upnp.html>`_
 

--- a/docs/discover.rst
+++ b/docs/discover.rst
@@ -24,7 +24,7 @@ cases.
 
 .. seealso::
 
-    The tools which have been provided with this library shows good use of the full library.
+    The scripts which have been provided with this library shows good use of the full library.
 
     `Additional short explanation of the UPnP protocol <http://www.upnp-hacks.org/upnp.html>`_
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ or even easier, execute:
     >>> print(device.getSystemInfo().manufactureName)
     "AVM"
 
-Also please see the `tools <https://github.com/bpannier/simpletr64/tree/master/simpletr64/tools>`_ which have been
+Also please see the `scripts <https://github.com/bpannier/simpletr64/tree/master/simpletr64/bin>`_ which have been
 provided with this library, these demonstrates the full functionality.
 
 Documentation

--- a/docs/tr64.rst
+++ b/docs/tr64.rst
@@ -62,7 +62,7 @@ send me the output of the following script execution:
 
 ::
 
-    > python tools/gather_device_upnp_info.py <name or IP of the device>
+    > simpletr64_deviceinfo <name or IP of the device>
 
 Please, send me the output via E-mail to: ``sourcecode@ka.ro``
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import sys
 import os
 from distutils.core import setup
 from codecs import open
+from glob import glob
 
 try:
     from setuptools import setup
@@ -37,7 +38,7 @@ setup(
     name='simpleTR64',
     version=version,
     packages=['simpletr64', 'simpletr64.actions', 'tests'],
-    scripts=['bin/simpletr64_discover', 'bin/simpletr64_deviceinfo', 'bin/simpletr64_execute'],
+    scripts=glob('bin/**'),
     install_requires=['requests'],
     url='http://bpannier.github.io/simpletr64/',
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     name='simpleTR64',
     version=version,
     packages=['simpletr64', 'simpletr64.tools', 'simpletr64.actions', 'tests'],
+    scripts=['bin/simpletr64_discover'],
     install_requires=['requests'],
     url='http://bpannier.github.io/simpletr64/',
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ with open('HISTORY.rst', 'r', 'utf-8') as f:
 setup(
     name='simpleTR64',
     version=version,
-    packages=['simpletr64', 'simpletr64.tools', 'simpletr64.actions', 'tests'],
-    scripts=['bin/simpletr64_discover'],
+    packages=['simpletr64', 'simpletr64.actions', 'tests'],
+    scripts=['bin/simpletr64_discover', 'bin/simpletr64_deviceinfo', 'bin/simpletr64_execute'],
     install_requires=['requests'],
     url='http://bpannier.github.io/simpletr64/',
     license='Apache 2.0',


### PR DESCRIPTION
The scripts have moved from the package into its own `bin` directory and are installed as scripts of the package.

The scripts are provisionally prefixed with `simpletr64` but can be changed before accepting this PR.
