### PR TITLE
Added requests version to install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     version=version,
     packages=['simpletr64', 'simpletr64.actions', 'tests'],
     scripts=glob('bin/**'),
-    install_requires=['requests'],
+    install_requires=['requests>=2.8.1'],
     url='http://bpannier.github.io/simpletr64/',
     license='Apache 2.0',
     author='Benjamin Pannier',


### PR DESCRIPTION
This makes pip install a newer version of the requests module when
requests is installed in an older version.
