### PR TITLE
Add verify parameter and authentication for loadDeviceDefinitions

### DIFF
--- a/simpletr64/actions/fritz.py
+++ b/simpletr64/actions/fritz.py
@@ -43,16 +43,18 @@ class Fritz(DeviceTR64):
         "getCallList": "urn:dslforum-org:service:X_AVM-DE_OnTel:1"
     }
 
-    def __init__(self, hostname, port=49000, protocol="http"):
+    def __init__(self, hostname, port=49000, protocol="http", verify=True):
         """Initialize the object.
 
         :param str hostname: hostname or IP address of the device
         :param int port: there is no default port usually, it is different per vendor. Default port for fritz.box is
             49000 and when encrypted 49443
         :param str protocol: protocol is either http or https
+        :param verify: Whether to verify the SSL certificate of the server, or the path of a certificate file (passed
+            to the verify parameter of requests.get / requests.post
         :rtype: Lan
         """
-        DeviceTR64.__init__(self, hostname, port, protocol)
+        DeviceTR64.__init__(self, hostname, port, protocol, verify)
 
     @staticmethod
     def createFromURL(urlOfXMLDefinition):

--- a/simpletr64/actions/lan.py
+++ b/simpletr64/actions/lan.py
@@ -43,16 +43,18 @@ class Lan(DeviceTR64):
         "setEnable": "urn:dslforum-org:service:LANEthernetInterfaceConfig:"
     }
 
-    def __init__(self, hostname, port=49000, protocol="http"):
+    def __init__(self, hostname, port=49000, protocol="http", verify=True):
         """Initialize the object.
 
         :param str hostname: hostname or IP address of the device
         :param int port: there is no default port usually, it is different per vendor. Default port for fritz.box is
             49000 and when encrypted 49443
         :param str protocol: protocol is either http or https
+        :param verify: Whether to verify the SSL certificate of the server, or the path of a certificate file (passed
+            to the verify parameter of requests.get / requests.post
         :rtype: Lan
         """
-        DeviceTR64.__init__(self, hostname, port, protocol)
+        DeviceTR64.__init__(self, hostname, port, protocol, verify)
 
     @staticmethod
     def createFromURL(urlOfXMLDefinition):

--- a/simpletr64/actions/system.py
+++ b/simpletr64/actions/system.py
@@ -38,16 +38,18 @@ class System(DeviceTR64):
         "softwareUpdateAvailable": "urn:dslforum-org:service:UserInterface:1"
     }
 
-    def __init__(self, hostname, port=49000, protocol="http"):
+    def __init__(self, hostname, port=49000, protocol="http", verify=True):
         """Initialize the object.
 
         :param str hostname: hostname or IP address of the device
         :param int port: there is no default port usually, it is different per vendor. Default port for fritz.box is
             49000 and when encrypted 49443
         :param str protocol: protocol is either http or https
+        :param verify: Whether to verify the SSL certificate of the server, or the path of a certificate file (passed
+            to the verify parameter of requests.get / requests.post
         :rtype: System
         """
-        DeviceTR64.__init__(self, hostname, port, protocol)
+        DeviceTR64.__init__(self, hostname, port, protocol, verify)
 
     @staticmethod
     def createFromURL(urlOfXMLDefinition):

--- a/simpletr64/actions/wan.py
+++ b/simpletr64/actions/wan.py
@@ -45,16 +45,18 @@ class Wan(DeviceTR64):
         "terminateConnection": "urn:dslforum-org:service:WANIPConnection:1"
     }
 
-    def __init__(self, hostname, port=49000, protocol="http"):
+    def __init__(self, hostname, port=49000, protocol="http", verify=True):
         """Initialize the object.
 
         :param str hostname: hostname or IP address of the device
         :param int port: there is no default port usually, it is different per vendor. Default port for fritz.box is
             49000 and when encrypted 49443
         :param str protocol: protocol is either http or https
+        :param verify: Whether to verify the SSL certificate of the server, or the path of a certificate file (passed
+            to the verify parameter of requests.get / requests.post
         :rtype: Wan
         """
-        DeviceTR64.__init__(self, hostname, port, protocol)
+        DeviceTR64.__init__(self, hostname, port, protocol, verify)
 
     @staticmethod
     def createFromURL(urlOfXMLDefinition):

--- a/simpletr64/actions/wifi.py
+++ b/simpletr64/actions/wifi.py
@@ -45,16 +45,18 @@ class Wifi(DeviceTR64):
         "setSSID": "urn:dslforum-org:service:WLANConfiguration:"
     }
 
-    def __init__(self, hostname, port=49000, protocol="http"):
+    def __init__(self, hostname, port=49000, protocol="http", verify=True):
         """Initialize the object.
 
         :param str hostname: hostname or IP address of the device
         :param int port: there is no default port usually, it is different per vendor. Default port for fritz.box is
             49000 and when encrypted 49443
         :param str protocol: protocol is either http or https
+        :param verify: Whether to verify the SSL certificate of the server, or the path of a certificate file (passed
+            to the verify parameter of requests.get / requests.post
         :rtype: Wifi
         """
-        DeviceTR64.__init__(self, hostname, port, protocol)
+        DeviceTR64.__init__(self, hostname, port, protocol, verify)
 
     @staticmethod
     def createFromURL(urlOfXMLDefinition):

--- a/simpletr64/devicetr64.py
+++ b/simpletr64/devicetr64.py
@@ -622,9 +622,14 @@ class DeviceTR64(object):
         # some devices response differently without a User-Agent
         headers = {"User-Agent": "Mozilla/5.0; SimpleTR64-1"}
 
+        # setup authentication
+        auth = None
+        if self.__password:
+            auth = HTTPDigestAuth(self.__username, self.__password)
+
         # get the content
         request = requests.get(urlOfXMLDefinition, proxies=proxies, headers=headers, timeout=float(timeout),
-                               verify=self.__verify)
+                               auth=auth, verify=self.__verify)
 
         if request.status_code != 200:
             errorStr = DeviceTR64._extractErrorString(request)

--- a/simpletr64/devicetr64.py
+++ b/simpletr64/devicetr64.py
@@ -28,19 +28,22 @@ class DeviceTR64(object):
     :type __deviceXMLInitialized: bool
     :type __deviceUnknownKeys: dict[str, str]
     """
-    def __init__(self, hostname, port=49000, protocol="http"):
+    def __init__(self, hostname, port=49000, protocol="http", verify=True):
         """Initialize a DeviceTR64 object.
 
         :param str hostname: hostname or IP address of the device
         :param int port: there is no default port usually, it is different per vendor. Default port for fritz.box is
             49000 and when encrypted 49443
         :param str protocol: protocol is either http or https
+        :param verify: Whether to verify the SSL certificate of the server, or the path of a certificate file (passed
+            to the verify parameter of requests.get / requests.post
         :return: an instance of class DeviceTR64
         :rtype: DeviceTR64
         """
         self.__hostname = hostname
         self.__portnumber = port
         self.__protocol = protocol
+        self.__verify = verify
 
         self.__username = ""
         self.__password = ""
@@ -446,7 +449,8 @@ class DeviceTR64(object):
         location = self.__protocol + "://" + self.__hostname + ":" + str(self.port) + uri
 
         # Post http request
-        request = requests.post(location, data=body, headers=header, auth=auth, proxies=proxies, timeout=float(timeout))
+        request = requests.post(location, data=body, headers=header, auth=auth, proxies=proxies, timeout=float(timeout),
+                               verify=self.__verify)
 
         if request.status_code != 200:
             errorStr = DeviceTR64._extractErrorString(request)
@@ -619,7 +623,8 @@ class DeviceTR64(object):
         headers = {"User-Agent": "Mozilla/5.0; SimpleTR64-1"}
 
         # get the content
-        request = requests.get(urlOfXMLDefinition, proxies=proxies, headers=headers, timeout=float(timeout))
+        request = requests.get(urlOfXMLDefinition, proxies=proxies, headers=headers, timeout=float(timeout),
+                               verify=self.__verify)
 
         if request.status_code != 200:
             errorStr = DeviceTR64._extractErrorString(request)
@@ -861,7 +866,8 @@ class DeviceTR64(object):
         headers = {"User-Agent": "Mozilla/5.0; SimpleTR64-2"}
 
         # http request
-        request = requests.get(location, auth=auth, proxies=proxies, headers=headers, timeout=timeout)
+        request = requests.get(location, auth=auth, proxies=proxies, headers=headers, timeout=timeout,
+                               verify=self.__verify)
 
         if request.status_code != 200:
             errorStr = DeviceTR64._extractErrorString(request)


### PR DESCRIPTION
When accessing TR-64 remotely on FritzBox devices, loading the tr64desc.xml file (through https://....myfritz.net:port/tr064/tr64desc.xml) also needs authentication. 157a624 adds this to the loadDeviceDefinitions function.

Additionally, I added a verify parameter to the constructors which is passed on to requests.get and requests.post to customize the verification of SSL certificates (a specific certificate can be trusted by specifying a file path or verification can be turned off by setting it to False).