### PR TITLE
Replace elementtree methods deprecated in Python 3.9

### DIFF
--- a/simpletr64/actions/fritz.py
+++ b/simpletr64/actions/fritz.py
@@ -208,12 +208,12 @@ class Fritz(DeviceTR64):
 
         calls = []
 
-        for child in root.getchildren():
+        for child in root:
             if child.tag.lower() == "call":
 
                 callParameters = {}
 
-                for callChild in child.getchildren():
+                for callChild in child:
                     callParameters[callChild.tag] = callChild.text
 
                 calls.append(callParameters)

--- a/simpletr64/devicetr64.py
+++ b/simpletr64/devicetr64.py
@@ -504,7 +504,7 @@ class DeviceTR64(object):
             # return an empty string as we can not parse the structure
             return errorStr
 
-        for element in tag.getiterator():
+        for element in tag.iter():
             tagName = element.tag.lower()
 
             if tagName.endswith("string"):
@@ -674,7 +674,7 @@ class DeviceTR64(object):
         :type element: xml.etree.ElementTree.Element
         :param str baseURIPath: the base URL
         """
-        for child in element.getchildren():
+        for child in element:
             tagName = child.tag.lower()
             if tagName.endswith('servicelist'):
                 self._processServiceList(child,baseURIPath)
@@ -732,7 +732,7 @@ class DeviceTR64(object):
         """
 
         # iterate through all children in serviceList XML tag
-        for service in serviceList.getchildren():
+        for service in serviceList:
 
             # has to be a service
             if not service.tag.lower().endswith("service"):
@@ -894,7 +894,7 @@ class DeviceTR64(object):
         variableParameterDict = {}
 
         # iterate through the full XML tree
-        for element in root.getchildren():
+        for element in root:
             tagName = element.tag.lower()
 
             # go deeper for action lists
@@ -932,12 +932,12 @@ class DeviceTR64(object):
         """
 
         # go through all action elements in this list
-        for actionElement in actionListElement.getchildren():
+        for actionElement in actionListElement:
 
             action = {}
 
             # go through all elements in this action
-            for inActionElement in actionElement.getchildren():
+            for inActionElement in actionElement:
                 tagName = inActionElement.tag.lower()
 
                 if tagName.endswith("name"):
@@ -945,12 +945,12 @@ class DeviceTR64(object):
                     action["name"] = inActionElement.text
                 elif tagName.endswith("argumentlist"):
                     # parse the arguments of this action
-                    for argumentElement in inActionElement.getchildren():
+                    for argumentElement in inActionElement:
 
                         argument = {}
 
                         # go through the argument definition
-                        for inArgumentElement in argumentElement.getchildren():
+                        for inArgumentElement in argumentElement:
                             tagName = inArgumentElement.tag.lower()
 
                             if tagName.endswith("name"):
@@ -1008,12 +1008,12 @@ class DeviceTR64(object):
         """
 
         # iterate through all variables
-        for variableElement in variableListElement.getchildren():
+        for variableElement in variableListElement:
 
             variable = {}
 
             # iterate through the variable definition
-            for inVariableElement in variableElement.getchildren():
+            for inVariableElement in variableElement:
                 tagName = inVariableElement.tag.lower()
 
                 if tagName.endswith("name"):

--- a/simpletr64/discover.py
+++ b/simpletr64/discover.py
@@ -211,7 +211,7 @@ class Discover:
             raise ValueError("Could not parse CPE definitions for '" + bestPick.location + "': " + str(e))
 
         # find the first deviceType in the document tree
-        for element in root.getiterator():
+        for element in root.iter():
             # check if element tag name ends on deviceType, skip XML namespace
             if element.tag.lower().endswith("devicetype"):
 


### PR DESCRIPTION
The methods `xml.etree.ElementTree.Element.getchildren()` and `getiterator()` were removed in Python 3.9 [1].
The 3.8 docs instruct to simply replace them with `list(elem)` and `elem.iter()` [2].

[1] https://docs.python.org/3/whatsnew/3.9.html#removed
[2] https://docs.python.org/3.8/library/xml.etree.elementtree.html?highlight=getiterator#xml.etree.ElementTree.Element.getchildren